### PR TITLE
Fix build by replacing node-sass with sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jsonwebtoken": "^9.0.2",
     "jsonschema": "^1.4.0",
     "lodash.get": "^4.4.2",
-    "node-sass": "^4.14.1",
+    "sass": "^1.69.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "renderjson": "^1.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,16 @@ module.exports = {
     rules: [
       {
         test: /\.s?css$/i,
-        use: ["style-loader", "css-loader", "sass-loader"],
+        use: [
+          "style-loader",
+          "css-loader",
+          {
+            loader: "sass-loader",
+            options: {
+              implementation: require("sass"),
+            },
+          },
+        ],
       },
       {
         test: /\.(png|jpeg|ttf|woff|woff2)$/,


### PR DESCRIPTION
## Summary
- replace deprecated `node-sass` with `sass`
- configure webpack to use dart-sass implementation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68475ca196c08327ae2e01dc3b3114b4